### PR TITLE
Use 'concurrency' in GitHub CI instead of external action

### DIFF
--- a/.github/workflows/builds-and-tests.yml
+++ b/.github/workflows/builds-and-tests.yml
@@ -29,6 +29,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   HYPRE_ARCHIVE: v2.19.0.tar.gz
   HYPRE_TOP_DIR: hypre-2.19.0
@@ -115,13 +119,6 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      # This external action allows to interrupt a workflow already running on
-      # the same branch to save resources.
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.12.1
-        with:
-          access_token: ${{ github.token }}
-
       # Fix 'No space left on device' errors for Ubuntu builds.
       - name: Run Actions Cleaner
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -18,6 +18,10 @@ on:
     # The branches below must be a subset of the branches above
     branches: ["master"]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/mfem-analysis.yml
+++ b/.github/workflows/mfem-analysis.yml
@@ -22,6 +22,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   HYPRE_ARCHIVE: v2.19.0.tar.gz
   HYPRE_TOP_DIR: hypre-2.19.0
@@ -32,12 +36,6 @@ env:
 jobs:
   gitignore:
     runs-on: ubuntu-latest
-
-    steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.12.1
-        with:
-          access_token: ${{ github.token }}
 
       - name: checkout MFEM
         uses: actions/checkout@v4

--- a/.github/workflows/mfem-analysis.yml
+++ b/.github/workflows/mfem-analysis.yml
@@ -37,6 +37,7 @@ jobs:
   gitignore:
     runs-on: ubuntu-latest
 
+    steps:
       - name: checkout MFEM
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/mfem-sanitizer.yml
+++ b/.github/workflows/mfem-sanitizer.yml
@@ -28,15 +28,9 @@ concurrency:
 
 jobs:
   Serial:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
-      - name: Temporary workaround for sanitizer crashes
-        # See https://github.com/actions/runner-images/issues/9491
-        # The issue should be fixed in the next runner image for Ubuntu 22.04,
-        # see https://github.com/actions/runner-images/pull/9513
-        run: sudo sysctl vm.mmap_rnd_bits=28
-
       - name: MFEM Checkout
         uses: actions/checkout@v4
         with:
@@ -54,7 +48,7 @@ jobs:
           build-system: make
           library-only: false
           config-options:
-            CXX="clang++"
+            CXX="clang++-18"
             CXXFLAGS="-g -O1 -std=c++11
                       -fsanitize=address
                       -fno-omit-frame-pointer

--- a/.github/workflows/mfem-sanitizer.yml
+++ b/.github/workflows/mfem-sanitizer.yml
@@ -22,6 +22,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   Serial:
     runs-on: ubuntu-latest
@@ -32,11 +36,6 @@ jobs:
         # The issue should be fixed in the next runner image for Ubuntu 22.04,
         # see https://github.com/actions/runner-images/pull/9513
         run: sudo sysctl vm.mmap_rnd_bits=28
-
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.12.1
-        with:
-          access_token: ${{ github.token }}
 
       - name: MFEM Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/mfem-sanitizer.yml
+++ b/.github/workflows/mfem-sanitizer.yml
@@ -54,7 +54,7 @@ jobs:
           build-system: make
           library-only: false
           config-options:
-            CXX="clang++-14"
+            CXX="clang++"
             CXXFLAGS="-g -O1 -std=c++11
                       -fsanitize=address
                       -fno-omit-frame-pointer

--- a/.github/workflows/repo-check.yml
+++ b/.github/workflows/repo-check.yml
@@ -19,6 +19,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 # This workflow is run on pushes to any branch in the MFEM repo (with or without
 # PRs), as well as on updates to PRs from forks. In particular, we do not
 # duplicate work by running on both pushes and updates to local PRs. We do that
@@ -33,11 +37,6 @@ jobs:
       (github.event_name == 'push' ||
        github.event.pull_request.head.repo.full_name != github.repository)
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.12.1
-        with:
-          access_token: ${{ github.token }}
-
       - name: checkout mfem
         uses: actions/checkout@v4
 


### PR DESCRIPTION
This is a built-in way to limit the CI to one job per workflow (canceling previous runs).